### PR TITLE
feat: Add logic to differ mnews and mirrordaily. Add mapping data for mirrordaily

### DIFF
--- a/server.py
+++ b/server.py
@@ -60,16 +60,10 @@ def sitemap_generator():
     requestFrom = msg.get('requestFrom', None)
     if target_objects==None:
         return "query parameters error"
-    if requestFrom == None:
-        return "query parameters error"
+    
     objects = [obj.strip() for obj in target_objects]
 
     app = os.environ.get('PROJECT_NAME', 'mnews')
-    if requestFrom == "mnews":
-        app = os.environ.get('PROJECT_NAME', 'mnews')
-    if requestFrom == "mirrordaily":
-        app = os.environ.get('PROJECT_NAME', 'mirrordaily')
-
     sitemap_news_days = os.environ.get('SITEMAP_NEWS_DAYS', 2)
     timezone  = pytz.timezone('Asia/Taipei')
 
@@ -132,10 +126,10 @@ def sitemap_generator():
             })
         if len(sitemap_files)>0:
             sitemap_index_xml = generate_sitemap_index(sitemap_files)
-            if requestFrom == 'mnews': 
-                upload_data(BUCKET, sitemap_index_xml, "Application/xml", os.path.join(folder, 'sitemap_index_newstab.xml'))
-            elif requestFrom == 'mirrordaily': 
+            if app == 'mirrordaily': 
                 upload_data(BUCKET, sitemap_index_xml, "Application/xml", os.path.join(folder, 'index.xml'))
+            else: 
+                upload_data(BUCKET, sitemap_index_xml, "Application/xml", os.path.join(folder, 'sitemap_index_newstab.xml'))
     return "ok"
     
 

--- a/sitemap.py
+++ b/sitemap.py
@@ -14,12 +14,20 @@ mnews_field_mapping = {
     'post': 'slug'
 }
 
+mirror_field_mapping = {
+    'post':'slug'
+}
+
 app_mapping = {
     'mnews': {
         'field_mapping': mnews_field_mapping,
         'publisher_name': '鏡電視',
-    }
+    },
     ### TODO: mapping for other app, eg. Readr
+    'mirrordaily':{
+        'field_mapping': mirror_field_mapping,
+        'publisher_name': '鏡報',
+    }
 }
 
 def generate_sitemap_index(sitemap_files):


### PR DESCRIPTION
這份PR 讓報紙沿用電視的邏輯 並且都串在同一個Readr的repo 
再根據報紙自己的規格 ->生成檔案名稱 ，藉由多加一個requestFrom的argument 讓電視跟報紙的程式邏輯分開
